### PR TITLE
RECAP-395 - Restrict duplicate accession for unavailable itembarcode

### DIFF
--- a/src/main/java/org/recap/RecapConstants.java
+++ b/src/main/java/org/recap/RecapConstants.java
@@ -282,6 +282,7 @@ public class RecapConstants {
     public static final String SUBMIT_COLLECTION_ITEM_BARCODE= "ItemBarcode";
     public static final String SUBMIT_COLLECTION_CUSTOMER_CODE= "CustomerCode";
     public static final String ITEM_BARCODE_NOT_FOUND_MSG = "Item Barcode not found";
+    public static final String ITEM_BARCODE_ALREADY_ACCESSIONED_MSG = "Unavailable barcode from partner is already accessioned";
     public static final String ACCESSION = "accession";
     public static final String DUMMYCALLNUMBER = "dummycallnumber";
     public static final String COMPLETE_STATUS = "Complete";
@@ -315,7 +316,7 @@ public class RecapConstants {
     public static final Integer NYPL_INST_ID = 3;
     public static final Integer CGD_SHARED = 1;
     public static final Integer CGD_OPEN = 2;
-    public static final Integer  HOLD= 1;
+    public static final Integer HOLD= 1;
     public static final Integer RETRIEVAL = 2;
     public static final Integer RECALL = 3;
     public static final Integer EDD = 4;

--- a/src/test/java/org/recap/service/accession/AccessionServiceUT.java
+++ b/src/test/java/org/recap/service/accession/AccessionServiceUT.java
@@ -67,6 +67,21 @@ public class AccessionServiceUT extends BaseTestCase {
     }
 
     @Test
+    public void accessionUnavilableBarcodeAvoidDuplicate(){
+        accessionService.processRequest("3210106212830", "PA", "PUL");
+        ItemEntity itemEntity = itemDetailsRepository.findByBarcode("3210106212830");
+        assertEquals(1,itemEntity.getBibliographicEntities().size());
+        assertNotNull(itemEntity);
+        assertEquals("dummycallnumber",itemEntity.getCallNumber());
+
+        String respose = accessionService.processRequest("3210106212830", "PA", "PUL");
+        assertEquals(RecapConstants.ITEM_BARCODE_ALREADY_ACCESSIONED_MSG,respose);
+        ItemEntity itemEntity1 = itemDetailsRepository.findByBarcode("3210106212830");
+        assertEquals(1,itemEntity1.getBibliographicEntities().size());
+
+    }
+
+    @Test
     public void processForNYPL(){
         accessionService.processRequest("33433002031718", "NA","NYPL");
         List<BibliographicEntity> fetchedBibliographicEntityList = bibliographicDetailsRepository.findByOwningInstitutionBibId(".b100000186");


### PR DESCRIPTION
RECAP-395 - Restrict duplicate accession for unavailable itembarcode